### PR TITLE
Fixed two bugs.

### DIFF
--- a/Model/PaymentManagement.php
+++ b/Model/PaymentManagement.php
@@ -203,12 +203,14 @@ class PaymentManagement implements PaylinePaymentManagementInterface
 
     public function wrapCallPaylineApiDoWebPaymentFacade($cartId)
     {
+        $cart = $this->cartRepository->getActive($cartId);
+
         $response = $this->callPaylineApiDoWebPaymentFacade(
-            $this->cartRepository->getActive($cartId), 
+            $cart,
             $this->cartTotalRepository->get($cartId),
             $this->quotePaymentMethodManagement->get($cartId),
             $this->quoteBillingAddressManagement->get($cartId),
-            $this->quoteShippingAddressManagement->get($cartId)
+            $cart->getIsVirtual() ? null : $this->quoteShippingAddressManagement->get($cartId)
         );
 
         return [

--- a/PaylineApi/Request/DoWebPayment.php
+++ b/PaylineApi/Request/DoWebPayment.php
@@ -93,7 +93,7 @@ class DoWebPayment extends AbstractRequest
         return $this;
     }
     
-    public function setShippingAddress(AddressInterface $shippingAddress)
+    public function setShippingAddress(AddressInterface $shippingAddress = null)
     {
         $this->shippingAddress = $shippingAddress;
         return $this;

--- a/PaylineApi/Response/GetMerchantSettings.php
+++ b/PaylineApi/Response/GetMerchantSettings.php
@@ -11,6 +11,9 @@ class GetMerchantSettings extends AbstractResponse
         $result = array();
         
         foreach($this->data['listPointOfSell']['pointOfSell'] as $pointOfSell) {
+
+            $contractsList = false;
+
             if (is_object($pointOfSell)) {
                 $contractsList    = $pointOfSell->contracts->contract;
                 $pointOfSellLabel = $pointOfSell->label;
@@ -21,21 +24,25 @@ class GetMerchantSettings extends AbstractResponse
                 $pointOfSellLabel = (!empty($pointOfSell['label'])) ? $pointOfSell['label']: '';
             }
 
-            if (!is_array($contractsList)) {
-                $contractsList = [$contractsList];
-            }
+            if($contractsList)
+            {
+                if (!is_array(reset($contractsList))) {
+                    // if there is only one level to the array, then there is only one contract
+                    $contractsList = [$contractsList];
+                }
 
-            foreach ($contractsList as $contract) {
-                $result[] = [
-                    'label' => $contract['label'],
-                    'number' => $contract['contractNumber'],
-                    'card_type' => $contract['cardType'],
-                    'currency' => isset($contract['currency']) ? $contract['currency'] : null,
-                    'point_of_sell_label' => $pointOfSellLabel,
-                ];
+                foreach ($contractsList as $contract) {
+                    $result[] = [
+                        'label' => $contract['label'],
+                        'number' => $contract['contractNumber'],
+                        'card_type' => $contract['cardType'],
+                        'currency' => isset($contract['currency']) ? $contract['currency'] : null,
+                        'point_of_sell_label' => $pointOfSellLabel,
+                    ];
+                }
             }
         }
-        
+
         return $result;
     }
 }


### PR DESCRIPTION
Points of sale with only one contract made the Store Config page crash, as the is_array() used to determine whether there was only one contract returned was not sufficient.
Virtual orders could not be placed because of absent shipping addresses.