### PR TITLE
Fixed another case of single-contract point of sale blocking Magento 2

### DIFF
--- a/PaylineApi/Response/GetMerchantSettings.php
+++ b/PaylineApi/Response/GetMerchantSettings.php
@@ -42,7 +42,7 @@ class GetMerchantSettings extends AbstractResponse
                     $pointOfSellLabel = (!empty($pointOfSell['label'])) ? $pointOfSell['label']: '';
                 }
 
-                if (!is_array($contractsList)) {
+                if (isset($contractsList['contractNumber'])) {
                     $contractsList = [$contractsList];
                 }
 


### PR DESCRIPTION
Or rather, its backend. There was another case I had previously missed of a response from Payline not being structured as the module expected and rendering the "Payment Methods" page of the Magento 2 backend unusable.

Can you please review and merge it ASAP? It is necessary to our project.

Thanks a lot in advance!